### PR TITLE
make music continue through scene reload

### DIFF
--- a/BackgroundMusic.tscn
+++ b/BackgroundMusic.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://assets/music/frogjutsu.mp3" type="AudioStream" id=1]
+
+[node name="BackgroundMusic" type="AudioStreamPlayer"]
+stream = ExtResource( 1 )
+volume_db = -17.952
+autoplay = true

--- a/main.tscn
+++ b/main.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://objects/Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://objects/tilesets/purple_tileset.tres" type="TileSet" id=2]
-[ext_resource path="res://assets/music/frogjutsu.mp3" type="AudioStream" id=3]
+[ext_resource path="res://BackgroundMusic.tscn" type="PackedScene" id=3]
 [ext_resource path="res://assets/images/background/2.png" type="Texture" id=4]
 [ext_resource path="res://objects/ui/UI.tscn" type="PackedScene" id=5]
 [ext_resource path="res://assets/images/background/3.png" type="Texture" id=6]
@@ -99,9 +99,8 @@ position = Vector2( 0, 710 )
 scale = Vector2( 200000, 10 )
 shape = SubResource( 1 )
 
-[node name="BackgroundMusic" type="AudioStreamPlayer" parent="."]
-stream = ExtResource( 3 )
-volume_db = -8.864
+[node name="BackgroundMusic" parent="." instance=ExtResource( 3 )]
+autoplay = false
 
 [node name="LargeFly" parent="." instance=ExtResource( 10 )]
 position = Vector2( 625.523, 140.326 )

--- a/project.godot
+++ b/project.godot
@@ -14,6 +14,10 @@ config/name="Slurp Ninja"
 run/main_scene="res://main.tscn"
 boot_splash/bg_color=Color( 0.109804, 0.0235294, 0.109804, 1 )
 
+[autoload]
+
+BackgroundMusic="*res://BackgroundMusic.tscn"
+
 [display]
 
 window/stretch/mode="2d"


### PR DESCRIPTION
This PR makes the music loop independently of the scene getting reloaded when the player presses retry after dying